### PR TITLE
Charger Research (11/20/2023)

### DIFF
--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -4,23 +4,11 @@
     "type": "split",
     "children": [
       {
-        "id": "b674543d4852d9b8",
+        "id": "9d586d6957d2535e",
         "type": "tabs",
         "children": [
           {
-            "id": "1cd64a65036f73a5",
-            "type": "leaf",
-            "state": {
-              "type": "markdown",
-              "state": {
-                "file": "CAN Bus/Dashboard CAN Protocol.md",
-                "mode": "source",
-                "source": false
-              }
-            }
-          },
-          {
-            "id": "d825e616f7595a50",
+            "id": "dbcd76f675a1c9ba",
             "type": "leaf",
             "state": {
               "type": "markdown",
@@ -32,36 +20,96 @@
             }
           },
           {
-            "id": "ddd57884fca4ff9c",
+            "id": "1a343b5abf47fa9d",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "Rules/EV.7 Electrical Shutdown/EV.7.6 Overcurrent Protection.md",
+                "file": "Component Research/Charging Research.md",
                 "mode": "source",
                 "source": false
               }
             }
           },
           {
-            "id": "ccde6674a1c05940",
+            "id": "6f354333689824a5",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "Daily Notes/2023-10-10.md",
+                "file": "Rules/EV.9 Charging/EV.9 Charging.md",
                 "mode": "source",
                 "source": false
               }
             }
           },
           {
-            "id": "c9e5c52028bef649",
+            "id": "9924c2aaed4fae03",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "CAN Bus/CAN bus general info.md",
+                "file": "Rules/IN.4 Electrical Technical Inspection.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          },
+          {
+            "id": "2fef7709bb112a80",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Rules/EV.9 Charging/EV.9.2 Charger Features.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          },
+          {
+            "id": "63cb58843e44d587",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Rules/EV.6 Energy Storage/EV.6.8 TSMP.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          },
+          {
+            "id": "066451810e35e865",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Rules/EV.9 Charging/EV.9.3 Charging Shutdown Circuit.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          },
+          {
+            "id": "c29468cd2c9dedf5",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Rules/EV.8 Shutdown System/EV.8.3 AMS.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          },
+          {
+            "id": "08cf51dd2b6f6a44",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Rules/EV.8 Shutdown System/EV.8.6 IMD.md",
                 "mode": "source",
                 "source": false
               }
@@ -142,7 +190,7 @@
             "state": {
               "type": "backlink",
               "state": {
-                "file": "Projects Master List.md",
+                "file": "Component Research/Charging Research.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -159,7 +207,7 @@
             "state": {
               "type": "outgoing-link",
               "state": {
-                "file": "Projects Master List.md",
+                "file": "Component Research/Charging Research.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               }
@@ -182,7 +230,7 @@
             "state": {
               "type": "outline",
               "state": {
-                "file": "Projects Master List.md"
+                "file": "Component Research/Charging Research.md"
               }
             }
           },
@@ -212,40 +260,41 @@
       "obsidian-excalidraw-plugin:Create new drawing": false
     }
   },
-  "active": "d825e616f7595a50",
+  "active": "1a343b5abf47fa9d",
   "lastOpenFiles": [
-    "CAN Bus/CAN bus.md",
+    "Projects Master List.md",
+    "Rules/EV.9 Charging/EV.9.3 Charging Shutdown Circuit.md",
+    "Rules/EV.6 Energy Storage/EV.6.8 TSMP.md",
+    "Rules/EV.9 Charging/EV.9.2 Charger Features.md",
+    "Rules/EV.9 Charging/EV.9 Charging.md",
+    "Component Research/Charging Research.md",
+    "Rules/EV.8 Shutdown System/EV.8.3 AMS.md",
+    "Rules/EV.8 Shutdown System/EV.8.6 IMD.md",
+    "Rules/IN.4 Electrical Technical Inspection.md",
+    "Rules/T.9 Electrical Equipment.md",
+    "HV Master List.md",
+    "Component Research/High Voltage Connectors Research.md",
+    "Component Research/Cascadia CM200DX Ordering.md",
     "Parts Checkout.md",
-    "CAN Bus/Dashboard CAN Protocol.md",
+    "Projects/Temp Monitor PCB.md",
+    "Projects/Remote Monitoring Dashboard.md",
+    "Projects/Discharge Circuit.md",
+    "Projects/TSAL.md",
+    "Onboarding.md",
     "CAN Bus/CAN bus general info.md",
+    "Daily Notes/2023-10-10.md",
+    "Rules/EV.7 Electrical Shutdown/EV.7.6 Overcurrent Protection.md",
+    "CAN Bus/Dashboard CAN Protocol.md",
+    "CAN Bus/CAN bus.md",
     "Excel 2023-11-12 13.12.47.sheet.md",
     "CAN Bus/CAN ID List.table",
-    "Projects Master List.md",
-    "Onboarding.md",
     "Untitled.loom",
     "Parts Checkout.csv",
     "New Text Document.txt",
     "Projects/VCU/Required Sensor Readings.md",
-    "Projects/VCU/VCU.md",
-    "Projects/VCU/VCU WiFi Module Firmware.md",
-    "Projects/VCU/VCU WiFi Expansion Card.md",
-    "Projects/VCU/VCU Exposed Hardware.md",
-    "Projects/Temperature Monitoring Firmware.md",
-    "Projects/Temp Monitor PCB.md",
-    "Projects/Remote Monitoring Dashboard.md",
-    "Projects/Dashboard Software.md",
-    "Projects/Dashboard.md",
     "Projects/VCU",
-    "Projects/Precharge Control.md",
-    "hi.md",
-    "Projects/Discharge Circuit.md",
-    "Rules/EV.7 Electrical Shutdown/EV.7.6 Overcurrent Protection.md",
-    "Projects/BSPD.md",
-    "Projects/Brake Light.md",
-    "Projects/Accumulator Indication Panel.md",
     "Shutdown Circuit 0V0.canvas",
     "Designs",
-    "Designs/ModuleAMS.md",
     "assets/Data Sheet 500V.pdf",
     "Untitled.canvas",
     "Datasheets/EnepaqVTC6A_Battery/Test of Sony US18650VTC6 3000mAh (Green).pdf",

--- a/Component Research/Charging Research.md
+++ b/Component Research/Charging Research.md
@@ -1,0 +1,44 @@
+**Background Research:**
+EVSE:
+- Electric Vehicle Supply Equipment is the technical name for charging stations for electric vehicles.
+- They provide electric power to the vehicle, as such recharging the accumulator.
+- EVSE systems include typical electric components to conduct energy transfer
+- EVSEs do not handle charging the accumulator, which is internal to the car itself, but directs energy to the charging port
+
+Levels:
+* Level 1 AC chargers intake from a 120V typical home wall outlet, and delivers power to the accumulator accordingly
+	* Incredibly slow, at 12-16A, and charge 1.4-1.9kW, charging minimal kilometres of range per hour
+* Level 2 AC chargers intake 240V (sometimes 208V), and supply power to the accumulator. Permanently wired to a dedicated circuit of the supplied voltage within a garage and/or driveway for typical EV vehicles.
+	* Between 12 and 80 amps of charge is typically supplied
+		* Most commonly 30-32A
+	* Adding the two together, power ranges from 2.88kW to 19.2kW (usually top out at 12kW though)
+		* With 30-32A, 7.2kW-7.68kW
+	* Cost approximates from $500-$2000 USD for consumer products.
+	* Compatible with industry-standard SAE J1772 (commonly refered to as "J-plug")
+* Level 3 DC fast charging stations intake from either a 240V (sometimes 208V) or 480V outlet on the grid it is hardwired to, and delivers power to the accumulator. Can also be 1000V, but those are not found at an EV homeowner's residence.
+	* Amperage is below 125A, typically 60A
+	* Charging loads usually start at 50kW and go up to 400kW and 900kW (depends on voltage standard and amperage supply)
+	* Compatible usually fall under one of the three standards: Superchargers (Tesla), SAE CCS (European EVs), and CHAdeMO (Asian EVs)
+
+**Formula E:**
+Regulation cuts:
+* [[EV.9.2 Charger Features]] lists under EV.9.2.1 that the charger must be a galvanically isolated AC input to DC output, immediately cutting off potential use of Level 3 charging stations, which uses DC input
+	* The incredibly slow speed of Level 1 chargers further implies that the right charging solution is a Level 2 charger implementation
+
+**Other teams:**
+* Research looking at past solutions developed by FSAE teams included a commonly presented power supply, specifically Elcon chargers, and more specifically the HK-J UHF models
+
+**Chargers:**
+Elcon HK-J 6.6kW charger:
+* Uses CANbus (can be bought with/without one)
+* Designed for electric vehicle LiFePO4/lithium/Lead acid battery and battery management system interface
+* Specs mention up to 95% power efficiency and over 93% full load efficiency
+* Input voltage range from AC90V to AC265V (45Hz-65Hz)
+* Output DC range depends on model:
+	* HK-J-H66-80: 18-68VDC Max DC output voltage range, 80A Max Current
+	* HK-J-H99-80: 25-99VDC Max DC output voltage range, 80A Max Current
+	* HK-J-H132-64: 34-132VDC Max DC output voltage range, 64A Max Current
+	* HK-J-H198-46: 50-198VDC Max DC output voltage range, 46A Max Current
+	* HK-J-H440-20: 110-440VDC Max DC output voltage range, 20A Max Current
+	* HK-J-H650-12: 170-650VDC Max DC output voltage range, 12A Max Current
+* Cost ranges across websites, no clear price range, but typically does not exceed 2000 USD


### PR DESCRIPTION
Includes background research on EVSEs, regulations affecting the charger itself, and research on the Elcon HK-J 6.6kW charger (most common charger). Further research is on pause until confirmation of battery pack/accumulator used, and other information to determine if Elcon products fit the needs, or if another product is required (or if the charger itself is also to be built from scratch by the team).